### PR TITLE
Fix CFFI warnings of deprecated usage of bare refererces to structs

### DIFF
--- a/src/clx/colormap.lisp
+++ b/src/clx/colormap.lisp
@@ -126,7 +126,7 @@
                             :blue (xcb-rgb-t-blue ptr)))
                          #'xcb-query-colors-colors
                          #'xcb-query-colors-colors-length
-                         reply 'xcb-rgb-t)))))
+                         reply '(:struct xcb-rgb-t))))))
 
  ;; 9.3.5 Changing Colors
 

--- a/src/clx/display.lisp
+++ b/src/clx/display.lisp
@@ -222,7 +222,7 @@
                                                              (xcb-format-t-scanline-pad ptr)))
                                        #'xcb-setup-pixmap-formats
                                        #'xcb-setup-pixmap-formats-length
-                                       setup 'xcb-format-t)))
+                                       setup '(:struct xcb-format-t))))
         (setf (%display-pixmap-formats display) formats))))
 
 (defun find-pixmap-format (display &key depth bpp)

--- a/src/clx/events.lisp
+++ b/src/clx/events.lisp
@@ -274,7 +274,7 @@
                              (xcb-timecoord-t-time ptr)))
                      #'xcb-get-motion-events-events
                      #'xcb-get-motion-events-events-length
-                     reply 'xcb-timecoord-t)))
+                     reply '(:struct xcb-timecoord-t))))
 
 (defun warp-pointer (destination dest-x dest-y)
   (xerr destination

--- a/src/clx/font.lisp
+++ b/src/clx/font.lisp
@@ -52,7 +52,7 @@
                      (cons (xcb-fontprop-t-name ptr)
                            (xcb-fontprop-t-value ptr)))
                    head-fn len-fn
-                   ptr 'xcb-fontprop-t))
+                   ptr '(:struct xcb-fontprop-t)))
 
 (defun query-font (font name)
   (do-request-response (font c reply err)
@@ -65,7 +65,7 @@
                              #'make-font-charinfo
                              #'xcb-query-font-char-infos
                              #'xcb-query-font-char-infos-length
-                             reply 'xcb-charinfo-t))))
+                             reply '(:struct xcb-charinfo-t)))))
 
 (defun open-font (display name)
   (xchk (display c id (font (%make-font :display display :id id)))

--- a/src/clx/util.lisp
+++ b/src/clx/util.lisp
@@ -109,7 +109,7 @@
        function
        (loop with ptr = (funcall head-function reply-pointer)
              for i from 0 below (funcall length-function reply-pointer)
-             collect (mem-aref ptr type i))))
+             collect (mem-aptr ptr type i))))
 
  ;; Copy to foreign array
 


### PR DESCRIPTION
These warnings were produced at runtime in potentially very large quantities.

An example warning:
WARNING:
   bare references to struct types are deprecated.
   Please use (:POINTER
               (:STRUCT
                XCB:XCB-CHARINFO-T))
           or (:STRUCT
               XCB:XCB-CHARINFO-T) instead.

Not all call sites of map-result-list were changed; for the ones left intact, I believe the calls are made with a non-struct type.

Some references to the same issue elsewhere on GitHub:
- https://github.com/edicl/cl-gd/issues/6
- https://github.com/cffi/cffi/pull/61